### PR TITLE
fix: trim whitespace in doorkey

### DIFF
--- a/js/src/admin/components/CreateDoorkeyModal.tsx
+++ b/js/src/admin/components/CreateDoorkeyModal.tsx
@@ -189,7 +189,7 @@ export default class CreateDoorkeyModal<CustomAttrs extends ICreateDoorkeyModalA
    */
   submitData(): SignupBody {
     const data = {
-      key: this.key(),
+      key: this.key().trim(),
       groupId: this.groupId(),
       maxUses: this.maxUses(),
       activates: this.activates(),

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -29,7 +29,7 @@ app.initializers.add('fof-doorman', () => {
 
   extend(SignUpModal.prototype, 'submitData', function (data) {
     const newData = data;
-    newData['fof-doorkey'] = this.doorkey;
+    newData['fof-doorkey'] = this.doorkey().trim();
     return newData;
   });
 });

--- a/migrations/2026_04_05_000000_trim_stored_doorkey_whitespace.php
+++ b/migrations/2026_04_05_000000_trim_stored_doorkey_whitespace.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of fof/doorman.
+ *
+ * Copyright (c) Reflar.
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+        $connection = $schema->getConnection();
+
+        if ($schema->hasColumn('users', 'invite_code')) {
+            $connection->table('users')
+                ->whereNotNull('invite_code')
+                ->orderBy('id')
+                ->chunk(500, function ($rows) use ($connection) {
+                    foreach ($rows as $row) {
+                        $normalized = strtoupper(trim((string) $row->invite_code));
+                        $stored = $normalized === '' ? null : $normalized;
+
+                        if ($stored !== $row->invite_code) {
+                            $connection->table('users')->where('id', $row->id)->update(['invite_code' => $stored]);
+                        }
+                    }
+                });
+        }
+
+        if ($schema->hasTable('doorkeys') && $schema->hasColumn('doorkeys', 'key')) {
+            $connection->table('doorkeys')
+                ->orderBy('id')
+                ->chunk(500, function ($rows) use ($connection) {
+                    foreach ($rows as $row) {
+                        $normalized = strtoupper(trim((string) $row->key));
+
+                        if ($normalized === '') {
+                            continue;
+                        }
+
+                        if ($normalized !== $row->key) {
+                            $connection->table('doorkeys')->where('id', $row->id)->update(['key' => $normalized]);
+                        }
+                    }
+                });
+        }
+    },
+
+    'down' => function (Builder $schema) {
+        // Irreversible: original spacing cannot be recovered.
+    },
+];

--- a/src/Commands/EditDoorkeyHandler.php
+++ b/src/Commands/EditDoorkeyHandler.php
@@ -56,9 +56,9 @@ class EditDoorkeyHandler
 
         $doorkey = Doorkey::where('id', $command->doorkeyId)->firstOrFail();
 
-        if (isset($attributes['key']) && '' !== $attributes['key']) {
-            $validate['key'] = strtoupper($attributes['key']);
-            $doorkey->key = strtoupper($attributes['key']);
+        if (isset($attributes['key']) && '' !== trim((string) $attributes['key'])) {
+            $doorkey->key = $attributes['key'];
+            $validate['key'] = $doorkey->key;
         }
 
         if (isset($attributes['groupId']) && '' !== $attributes['groupId']) {

--- a/src/Doorkey.php
+++ b/src/Doorkey.php
@@ -35,10 +35,20 @@ class Doorkey extends AbstractModel
      */
     protected $table = 'doorkeys';
 
+    /**
+     * Normalize the key attribute on write: trim whitespace and uppercase.
+     *
+     * @param string|null $value
+     */
+    public function setKeyAttribute($value)
+    {
+        $this->attributes['key'] = strtoupper(trim((string) $value));
+    }
+
     public static function build($key, $groupId, $maxUses, $activates)
     {
         $doorkey = new static();
-        $doorkey->key = strtoupper($key);
+        $doorkey->key = $key;
         $doorkey->group_id = $groupId;
         $doorkey->max_uses = $maxUses;
         $doorkey->activates = $activates;

--- a/src/Listeners/AddValidatorRule.php
+++ b/src/Listeners/AddValidatorRule.php
@@ -15,16 +15,18 @@ namespace FoF\Doorman\Listeners;
 
 use Flarum\Foundation\AbstractValidator;
 use Flarum\Settings\SettingsRepositoryInterface;
-use FoF\Doorman\Doorkey;
+use FoF\Doorman\Repository\DoorkeyRepository;
 use Illuminate\Validation\Validator;
 
 class AddValidatorRule
 {
     protected $settings;
+    protected $doorkeys;
 
-    public function __construct(SettingsRepositoryInterface $settings)
+    public function __construct(SettingsRepositoryInterface $settings, DoorkeyRepository $doorkeys)
     {
         $this->settings = $settings;
+        $this->doorkeys = $doorkeys;
     }
 
     public function __invoke(AbstractValidator $flarumValidator, Validator $validator)
@@ -32,7 +34,7 @@ class AddValidatorRule
         $validator->addExtension(
             'doorkey',
             function ($attribute, $value, $parameters) {
-                $doorkey = Doorkey::where('key', $value)->first();
+                $doorkey = $this->doorkeys->getByKey((string) $value);
 
                 // Allows the invitation key to be optional if the setting was enabled
                 $allow = json_decode($this->settings->get('fof-doorman.allowPublic'));

--- a/src/Listeners/ValidateDoorkey.php
+++ b/src/Listeners/ValidateDoorkey.php
@@ -15,8 +15,8 @@ namespace FoF\Doorman\Listeners;
 
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\Event\Saving;
-use FoF\Doorman\Doorkey;
 use FoF\Doorman\DoorkeyBypassRegistry;
+use FoF\Doorman\Repository\DoorkeyRepository;
 use FoF\Doorman\Validators\DoorkeyLoginValidator;
 use Illuminate\Support\Arr;
 
@@ -25,15 +25,18 @@ class ValidateDoorkey
     protected $validator;
     protected $settings;
     protected $registry;
+    protected $doorkeys;
 
     public function __construct(
         DoorkeyLoginValidator $validator,
         SettingsRepositoryInterface $settings,
-        DoorkeyBypassRegistry $registry
+        DoorkeyBypassRegistry $registry,
+        DoorkeyRepository $doorkeys
     ) {
         $this->validator = $validator;
         $this->settings = $settings;
         $this->registry = $registry;
+        $this->doorkeys = $doorkeys;
     }
 
     /**
@@ -53,7 +56,7 @@ class ValidateDoorkey
                 return;
             }
 
-            $key = strtoupper(Arr::get($event->data, 'attributes.fof-doorkey'));
+            $key = strtoupper(trim((string) Arr::get($event->data, 'attributes.fof-doorkey')));
 
             // Allows the invitation key to be optional if the setting was enabled
             $allow = json_decode($this->settings->get('fof-doorman.allowPublic'));
@@ -66,7 +69,7 @@ class ValidateDoorkey
             ]);
             $event->user->invite_code = $key;
 
-            $doorkey = Doorkey::where('key', $key)->first();
+            $doorkey = $this->doorkeys->getByKey($key);
 
             if ($doorkey->activates) {
                 $event->user->activate();

--- a/src/Repository/DoorkeyRepository.php
+++ b/src/Repository/DoorkeyRepository.php
@@ -42,6 +42,16 @@ class DoorkeyRepository
 
     public function getByKey(?string $key): ?Doorkey
     {
-        return $this->query()->where('key', $key)->first();
+        if ($key === null) {
+            return null;
+        }
+
+        $normalized = strtoupper(trim($key));
+
+        if ($normalized === '') {
+            return null;
+        }
+
+        return $this->query()->where('key', $normalized)->first();
     }
 }

--- a/tests/integration/OAuthBypassTest.php
+++ b/tests/integration/OAuthBypassTest.php
@@ -22,6 +22,7 @@ use FoF\Doorman\DoorkeyBypassRegistry;
 use FoF\Doorman\Extend\BypassDoorkey;
 use FoF\Doorman\Listeners\OAuthBypassDoorkey;
 use FoF\Doorman\Listeners\ValidateDoorkey;
+use FoF\Doorman\Repository\DoorkeyRepository;
 use FoF\Doorman\Validators\DoorkeyLoginValidator;
 
 class OAuthBypassTest extends TestCase
@@ -144,7 +145,8 @@ class OAuthBypassTest extends TestCase
         // Create the validator listener
         $validator = $app->getContainer()->make(DoorkeyLoginValidator::class);
         $settings = $app->getContainer()->make(SettingsRepositoryInterface::class);
-        $validateListener = new ValidateDoorkey($validator, $settings, $registry);
+        $doorkeys = $app->getContainer()->make(DoorkeyRepository::class);
+        $validateListener = new ValidateDoorkey($validator, $settings, $registry, $doorkeys);
 
         // Handle the event
         $validateListener->handle($event);


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Previously, invite codes could be submitted or stored with leading or trailing spaces.
<img width="643" height="39" alt="image" src="https://github.com/user-attachments/assets/8171e5c9-0798-4e3a-abfb-d32bcc4f63bc" />

This PR normalizes keys consistently everywhere, and adds a one-time migration to clean existing rows.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
