### PR TITLE
fix(2.0): replace removed @config-dark-mode LESS variable

### DIFF
--- a/resources/less/admin.less
+++ b/resources/less/admin.less
@@ -75,7 +75,7 @@
       &--shaded {
         background: var(--body-bg-shaded);
 
-        & when (@config-dark-mode = true) {
+        [data-theme^=dark] & {
           background: var(--body-bg-light);
         }
       }


### PR DESCRIPTION
## Problem

The admin LESS fails to compile on Flarum 2.0:

> variable @config-dark-mode is undefined in `resources/less/admin.less`

`@config-dark-mode` was a Flarum **1.x** compile-time LESS variable. Flarum 2.0 reworked theming around the `[data-theme]` attribute, so that variable no longer exists — breaking the admin stylesheet build.

## Fix

Replace the 1.x guard with the 2.0 attribute selector, matching core's own `UsersListPage` styles:

```less
- & when (@config-dark-mode = true) {
+ [data-theme^=dark] & {
```

`[data-theme^=dark]` matches both `dark` and `dark-hc`. This was the only stale `@config-*` reference in the extension.

> Follow-up to #72 — this one-line LESS fix was missed before that PR merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)