### PR TITLE
fix(2.0): accept fof-doorkey attribute during registration

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -13,6 +13,8 @@
 
 namespace FoF\Doorman;
 
+use Flarum\Api\Resource\UserResource;
+use Flarum\Api\Schema;
 use Flarum\Extend;
 use Flarum\Search\Database\DatabaseSearchDriver;
 use Flarum\User\Event\Registered;
@@ -67,4 +69,16 @@ return [
         ->register(DoorkeyServiceProvider::class),
 
     new Extend\ApiResource(Api\Resource\DoorkeyResource::class),
+
+    // Accept the `fof-doorkey` attribute submitted during registration. It is a
+    // transient, write-only input — the value is consumed by the ValidateDoorkey
+    // listener (on the User `Saving` event), so the field itself does not persist.
+    (new Extend\ApiResource(UserResource::class))
+        ->fields(fn () => [
+            Schema\Str::make('fof-doorkey')
+                ->writableOnCreate()
+                ->nullable()
+                ->visible(false)
+                ->set(fn () => null),
+        ]),
 ];

--- a/tests/integration/forum/RegisterWithDoorkeyTest.php
+++ b/tests/integration/forum/RegisterWithDoorkeyTest.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * This file is part of fof/doorman.
+ *
+ * Copyright (c) Reflar.
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace FoF\Doorman\Tests\integration\forum;
+
+use Flarum\Extend;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use FoF\Doorman\Doorkey;
+use PHPUnit\Framework\Attributes\Test;
+
+class RegisterWithDoorkeyTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extend(
+            (new Extend\Csrf())->exemptRoute('register')
+        );
+
+        // Require a doorkey to register.
+        $this->setting('fof-doorman.allowPublic', 'false');
+        $this->setting('allow_sign_up', '1');
+        $this->setting('mail_driver', 'log');
+
+        $this->extension('fof-doorman');
+
+        $this->prepareDatabase([
+            'doorkeys' => [
+                // group_id 4 (Mods): PostRegisterOperations skips the default
+                // Members group (3), so a non-default group lets us assert the
+                // group was actually attached.
+                ['id' => 1, 'key' => 'TESTKEY1', 'group_id' => 4, 'max_uses' => 10, 'uses' => 0, 'activates' => 1],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function guest_can_register_with_a_valid_doorkey()
+    {
+        $response = $this->send(
+            $this->request('POST', '/register', [
+                'json' => [
+                    'username'    => 'doorkeyuser',
+                    'email'       => 'doorkeyuser@machine.local',
+                    'password'    => 'too-obscure',
+                    'fof-doorkey' => 'TESTKEY1',
+                ],
+            ])
+        );
+
+        $this->assertEquals(201, $response->getStatusCode(), (string) $response->getBody());
+
+        $user = User::where('username', 'doorkeyuser')->firstOrFail();
+
+        // The doorkey was consumed and recorded against the user.
+        $this->assertEquals('TESTKEY1', $user->invite_code);
+
+        // The user was added to the doorkey's group.
+        $this->assertTrue($user->groups->pluck('id')->contains(4), 'User should be added to the doorkey group');
+
+        // The doorkey's usage counter was incremented.
+        $this->assertEquals(1, Doorkey::find(1)->uses, 'Doorkey usage should be incremented');
+    }
+
+    #[Test]
+    public function guest_cannot_register_with_an_invalid_doorkey()
+    {
+        $response = $this->send(
+            $this->request('POST', '/register', [
+                'json' => [
+                    'username'    => 'baduser',
+                    'email'       => 'baduser@machine.local',
+                    'password'    => 'too-obscure',
+                    'fof-doorkey' => 'WRONGKEY',
+                ],
+            ])
+        );
+
+        $this->assertEquals(422, $response->getStatusCode());
+        $this->assertNull(User::where('username', 'baduser')->first());
+        $this->assertEquals(0, Doorkey::find(1)->uses);
+    }
+
+    #[Test]
+    public function guest_cannot_register_without_a_doorkey_when_required()
+    {
+        $response = $this->send(
+            $this->request('POST', '/register', [
+                'json' => [
+                    'username' => 'nokeyuser',
+                    'email'    => 'nokeyuser@machine.local',
+                    'password' => 'too-obscure',
+                ],
+            ])
+        );
+
+        $this->assertEquals(422, $response->getStatusCode());
+        $this->assertNull(User::where('username', 'nokeyuser')->first());
+    }
+
+    #[Test]
+    public function guest_can_register_without_a_doorkey_when_optional()
+    {
+        // When public registration is allowed, the doorkey becomes optional.
+        $this->setting('fof-doorman.allowPublic', 'true');
+
+        $response = $this->send(
+            $this->request('POST', '/register', [
+                'json' => [
+                    'username' => 'publicuser',
+                    'email'    => 'publicuser@machine.local',
+                    'password' => 'too-obscure',
+                ],
+            ])
+        );
+
+        $this->assertEquals(201, $response->getStatusCode(), (string) $response->getBody());
+
+        $user = User::where('username', 'publicuser')->firstOrFail();
+
+        // No doorkey was supplied, so none was recorded or consumed.
+        $this->assertEmpty($user->invite_code);
+        $this->assertEquals(0, Doorkey::find(1)->uses);
+    }
+}


### PR DESCRIPTION
## Problem

Registering with an invite code fails on Flarum 2.0:

> `POST /register` → **Unknown field [fof-doorkey]** (HTTP 400)

In 2.0 the `UserResource` Create endpoint validates incoming attributes against its schema and rejects anything undeclared (`assertFieldsExist`). The signup form submits a `fof-doorkey` attribute, which was never registered — so the request 400'd before the `ValidateDoorkey` listener (on the User `Saving` event) ever ran.

## Fix

Register `fof-doorkey` as a field on the User resource:

```php
(new Extend\ApiResource(UserResource::class))
    ->fields(fn () => [
        Schema\Str::make('fof-doorkey')
            ->writableOnCreate()   // only relevant at registration
            ->nullable()
            ->visible(false)       // write-only; never serialized back
            ->set(fn () => null),  // transient — does not persist a column
    ]),
```

The value is still consumed by the existing `ValidateDoorkey` listener via the `Saving` event (which reads the raw request body), so validation, `invite_code`, group assignment and usage counting all keep working.

## Tests

This bug slipped through because there was **no end-to-end registration test** — the existing tests called listeners directly, bypassing the API layer. Added `tests/integration/forum/RegisterWithDoorkeyTest.php` (modeled on core's `RegisterTest`), covering registration:

- ✅ with a valid doorkey → 201, user added to the key's group, usage incremented
- ✅ with an invalid doorkey → 422, no user created, usage unchanged
- ✅ without a doorkey when one is required → 422
- ✅ without a doorkey when public sign-up is allowed → 201

Verified the happy-path test reproduces the exact `Unknown field [fof-doorkey]` 400 without the fix. Full suite: 25 tests green on MySQL and SQLite; PHPStan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)